### PR TITLE
progression initialisation des tournées

### DIFF
--- a/client/statics/notSecure/style.css
+++ b/client/statics/notSecure/style.css
@@ -88,3 +88,11 @@ header {
 #dietsSummary tfoot {
     font-weight: bold;
 }
+
+.notransition {
+  -webkit-transition: none !important;
+  -moz-transition: none !important;
+  -o-transition: none !important;
+  -ms-transition: none !important;
+  transition: none !important;
+}

--- a/client/tourComputing.ejs
+++ b/client/tourComputing.ejs
@@ -73,7 +73,7 @@
 
           $('#computeProgress .progress-bar').removeClass("notransition");
 
-          if(value == 0) {
+          if(value == 0 || value > 90) {
 
             $('#computeProgress .progress-bar').addClass("notransition");
 

--- a/client/tourComputing.ejs
+++ b/client/tourComputing.ejs
@@ -71,8 +71,16 @@
 
         socket.on('generationProgress', function(value) {
 
-        $('#computeProgress .progress-bar').css('width', value + '%');
-        $('#computeProgress .progress-bar > .sr-only').text(value + '% Complete');
+          $('#computeProgress .progress-bar').removeClass("notransition");
+
+          if(value == 0) {
+
+            $('#computeProgress .progress-bar').addClass("notransition");
+
+          }
+
+          $('#computeProgress .progress-bar').css('width', value + '%');
+          $('#computeProgress .progress-bar > .sr-only').text(value + '% Complete');
 
         });
 

--- a/client/tourComputing.ejs
+++ b/client/tourComputing.ejs
@@ -27,6 +27,8 @@
       // execute le javascript quand la page est completement chargee
       $(document).ready(function() {
 
+        $('#computeProgress').css('visibility', 'hidden');
+
         $('nav #tourComputingLink').addClass('active');
 
         const csvParse = require('csv-parse');
@@ -67,9 +69,18 @@
 
         });
 
+        socket.on('generationProgress', function(value) {
+
+        $('#computeProgress .progress-bar').css('width', value + '%');
+        $('#computeProgress .progress-bar > .sr-only').text(value + '% Complete');
+
+        });
+
         socket.on('started', function() {
 
           $('#infos').empty();
+
+          $('#computeProgress').css('visibility', 'visible');
 
           $('#startGa').prop("disabled", true);
           $('#stopGa').prop("disabled", false);
@@ -104,6 +115,8 @@
           });
 
           let infosList = $('#infos');
+
+          infosList.empty();
 
           // infosList.append($('<div class="row">').append($('<div class="col-xs-12">')).html("génération " + bestResult.genNumber));
           // infosList.append($('<div class="row">').append($('<div class="col-xs-12">')).text('id partition : ' + bestResult.partitionId));
@@ -205,6 +218,11 @@
             <div id="map"></div>
           </div>
           <div class="col-xs-3">
+            <div class="progress" id="computeProgress">
+              <div class="progress-bar progress-bar-info progress-bar-striped" role="progressbar" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" style="width: 0%">
+                <span class="sr-only">0% Complete</span>
+              </div>
+            </div>
             <p id="infos">
             </p>
           </div>

--- a/client/tourComputing.ejs
+++ b/client/tourComputing.ejs
@@ -84,6 +84,18 @@
 
         });
 
+        socket.on('timeProgress', function(value) {
+
+          let remainingMin = Math.round((value.max-value.runTime)/60000);
+
+          let h = Math.floor(remainingMin/60);
+          let m = remainingMin%60;
+
+          $('#timeProgress .progress-bar').css('width', 100*value.runTime/value.max + '%');
+          $('#timeProgress .progress-bar > #timeProgressTextTime').text(h+'h'+m);
+
+        });
+
         socket.on('started', function() {
 
           $('#infos').empty();
@@ -226,6 +238,11 @@
             <div id="map"></div>
           </div>
           <div class="col-xs-3">
+            <div class="progress" id="timeProgress">
+              <div class="progress-bar progress-bar-warning" role="progressbar" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" style="min-width: 6em; width: 0%">
+                reste <span id="timeProgressTextTime">00h00</span>
+              </div>
+            </div>
             <div class="progress" id="computeProgress">
               <div class="progress-bar progress-bar-info progress-bar-striped" role="progressbar" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" style="width: 0%">
                 <span class="sr-only">0% Complete</span>

--- a/server/ga2.js
+++ b/server/ga2.js
@@ -66,9 +66,8 @@ exports.start = function(params, socket) {
             console.log(err);
           } else
             console.log('initial pop sent');
+            reproduceForever(pop);
         });
-
-      reproduceForever(pop);
 
     });
 
@@ -844,6 +843,8 @@ exports.start = function(params, socket) {
                     console.log('partitioning #' + i + ' trip computed, done');
 
                     population.push(partition);
+
+                    socket.emit('generationProgress', population.length*100/POPULATION_SIZE);
 
                     if (population.length == POPULATION_SIZE) {
 

--- a/server/ga2.js
+++ b/server/ga2.js
@@ -19,13 +19,21 @@ exports.stop = function() {
 exports.start = function(params, socket) {
 
   let nbTrips = params.nbTrips;
-  // const POPULATION_SIZE = 168;
-  const POPULATION_SIZE = 20;
+  const POPULATION_SIZE = 168;
+  // const POPULATION_SIZE = 20;
 
 
   const STOP_TIME = params.stopTime * 60;
 
-  const MAX_RUN_TIME = 1;// le temps maximum de calcul en minutes
+  const MAX_RUN_TIME = 13*60;// le temps maximum de calcul en minutes
+
+  const MS_MAX_RUN_TIME = MAX_RUN_TIME*60000;
+
+  let startRunTime = Date.now();
+
+  let runTime = Date.now()-startRunTime;
+
+  socket.emit('timeProgress', {runTime : runTime, max : MS_MAX_RUN_TIME});
 
   let progress = 0;
 
@@ -73,8 +81,6 @@ exports.start = function(params, socket) {
   const ELITISM_PERCENT = 7 / 100;
 
   const ELECTED_COUNT = Math.round(POPULATION_SIZE * ELITISM_PERCENT);
-
-  const MAX_GEN_WITHOUT_BETTER = Infinity;
 
   /**
    * en fonction du pourcentage d'elitisme,
@@ -184,7 +190,11 @@ exports.start = function(params, socket) {
               console.log(err);
             } else {
 
-              if (forever && bestResult.genNumber + MAX_GEN_WITHOUT_BETTER > genCount) {
+              let runTime = Date.now()-startRunTime;
+
+              socket.emit('timeProgress', {runTime : runTime, max : MS_MAX_RUN_TIME});
+
+              if (forever && runTime < MS_MAX_RUN_TIME) {
 
                 progress=0;
                 socket.emit('generationProgress', 0);

--- a/server/ga2.js
+++ b/server/ga2.js
@@ -23,6 +23,8 @@ exports.start = function(params, socket) {
   // const POPULATION_SIZE = 16;
   const STOP_TIME = params.stopTime * 60;
 
+  let progress = 0;
+
   // le nombre minimal et max d'elements dans un sous ensemble pour qu'il soit accepté
   const MIN_ELEMENTS = 22;
 
@@ -134,6 +136,8 @@ exports.start = function(params, socket) {
 
             socket.emit('bestResult', bestResult);
 
+            console.log('new gen sent');
+
             console.log('best : ');
             console.log(partition);
 
@@ -183,8 +187,9 @@ exports.start = function(params, socket) {
             if (err) {
               console.log('error when sending new generation');
               console.log(err);
-            } else
-              console.log('new gen sent');
+            } else {
+
+            }
           });
 
         if (forever && bestResult.genNumber + MAX_GEN_WITHOUT_BETTER > genCount)
@@ -243,6 +248,9 @@ exports.start = function(params, socket) {
 
       console.log('');
       console.log(' **************** nextGeneration **************** ');
+
+      progress=0;
+      socket.emit('generationProgress', 0);
 
       let pop = elect(currentPop);
 
@@ -609,6 +617,9 @@ exports.start = function(params, socket) {
               return a.duration - b.duration
             });
 
+            progress++;
+            socket.emit('generationProgress', progress*100/POPULATION_SIZE);
+
             resolve(this);
           });
 
@@ -843,8 +854,6 @@ exports.start = function(params, socket) {
                     console.log('partitioning #' + i + ' trip computed, done');
 
                     population.push(partition);
-
-                    socket.emit('generationProgress', population.length*100/POPULATION_SIZE);
 
                     if (population.length == POPULATION_SIZE) {
 

--- a/server/ga2.js
+++ b/server/ga2.js
@@ -28,13 +28,6 @@ exports.start = function(params, socket) {
   // le nombre minimal et max d'elements dans un sous ensemble pour qu'il soit accepté
   const MIN_ELEMENTS = 22;
 
-  // if (params.maxStops < MIN_ELEMENTS * 2) {
-
-  //   socket.emit('maxTooSmall');
-  //   return;
-  // }
-  // const MAX_ELEMENTS = params.maxStops - MIN_ELEMENTS;
-
   const MAX_ELEMENTS = Infinity;
 
   console.log('starting ga');
@@ -78,8 +71,6 @@ exports.start = function(params, socket) {
   const ELECTED_COUNT = Math.round(POPULATION_SIZE * ELITISM_PERCENT);
 
   const MAX_GEN_WITHOUT_BETTER = Infinity;
-
-  // let idealNbElementsInSubset; // calcule dans firtPopuplation apres avoir pris connaissance du nombre d'adresses et du nbTrips demande
 
   /**
    * en fonction du pourcentage d'elitisme,
@@ -130,9 +121,6 @@ exports.start = function(params, socket) {
             bestResult.totalTime = totalTime;
 
             bestResult.trips = partition.subsetsTrips;
-
-            // common.writeJson(common.serverConfig.resultsFolder + '/bestTours' + utils.currentDateTimeString() +
-            //   '.json', bestResult);
 
             socket.emit('bestResult', bestResult);
 
@@ -200,9 +188,6 @@ exports.start = function(params, socket) {
 
           manageTours.fillDb(bestResult.trips);
 
-          // common.writeJson(common.serverConfig.resultsFolder + '/bestTours' + utils.currentDateTimeString() +
-          //   '.json', bestResult);
-
           let timeSinceBest = (Date.now() - timeLastBest);
 
           console.log(timeSinceBest / 1000 + ' sec without better result');
@@ -261,19 +246,10 @@ exports.start = function(params, socket) {
 
         let child = mate(firstParent, weightedRouletteWheel(currentPop, firstParent.id));
 
-        // pop.push(child);
-
         if (acceptChild(child))
           pop.push(child);
         else
           pop.push(randomChunkify(currentPop[0].subsets[0].addressesGeoJson, nbTrips));
-
-        // else {
-        //   // forever = false;
-        //   // console.log('vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv child vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv');
-        //   // console.log(child.subsets);
-        //   // console.log(' ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ child ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ');
-        // }
       }
 
       let promises = [];
@@ -833,7 +809,6 @@ exports.start = function(params, socket) {
               }
 
               let totalAddresses = addresses.albi.length;
-              // idealNbElementsInSubset = totalAddresses / nbTrips;
 
               return addresses;
 
@@ -887,7 +862,6 @@ exports.start = function(params, socket) {
     for (let part of population) {
 
       part.fitness = HIGH - part.subsets[part.subsets.length - 1].duration + 1;
-      // part.fitness = HIGH + 1 - part.subsets[part.subsets.length - 1].duration;
 
       cumulatedFitness += part.fitness;
 

--- a/server/manageTours.js
+++ b/server/manageTours.js
@@ -31,6 +31,8 @@ function fillDb(tours) {
     })
     .then(() => {
 
+      let addressesToursAssignments = [];
+
       for (let i in tours) {
 
         let tour = tours[i];
@@ -38,9 +40,6 @@ function fillDb(tours) {
         // common.writeFile(TARGET_DIRECTORY + '/tourTrip' + i + '.json', JSON.stringify(
         //   tour.trip.trips[0], null, 2));
 
-        let dbCon = mysql.createConnection(common.serverConfig.db);
-
-        let addressesToursAssignments = [];
 
         for (let j in tour.addresses.features) {
 
@@ -56,13 +55,15 @@ function fillDb(tours) {
 
         }
 
-        db.assignAddressesToTours(addressesToursAssignments, dbCon)
-          .then(() => { dbCon.end(); });
-
         // common.writeFile(TARGET_DIRECTORY + '/tourAddresses' + i + '.json', JSON.stringify(
         //   tour.addresses, null, 2));
 
       }
+
+      let dbCon = mysql.createConnection(common.serverConfig.db);
+
+      db.assignAddressesToTours(addressesToursAssignments, dbCon)
+        .then(() => { dbCon.end(); });
 
     });
 }


### PR DESCRIPTION
avec ce patch on peut sélectionner dans le code de ga2.js le temps maximum de calcul (13h actuellement)
et côté client on a maintenant 2 barres de progression qui nous montrent l'avancé du calcul.

Voilà pour la partie Initialisation des tournées mentionné dans #2 